### PR TITLE
Fix modelValue not triggering recalculation of internalValue

### DIFF
--- a/src/mixins/treeselectMixin.js
+++ b/src/mixins/treeselectMixin.js
@@ -870,7 +870,7 @@ export default {
       this.$emit('search-change', this.trigger.searchQuery, this.getInstanceId())
     },
 
-    value() {
+    modelValue() {
       const nodeIdsFromValue = this.extractCheckedNodeIdsFromValue()
       const hasChanged = quickDiff(nodeIdsFromValue, this.internalValue)
       if (hasChanged) this.fixSelectedNodeIds(nodeIdsFromValue)


### PR DESCRIPTION
Hi aman. Thank you for your work with the vue3 migration.

There is a bug if you change modelValue from the parent, the internalValue does not update and the internal list doesnt change.

Steps to reproduce
1. Select some items from options, using the multiple prop.
2. In the parent, reset the modelValue to [].
3. Notice the parent has the modelValue as [] but the internalValue of the treeselect still has items in.

I believe this is because value was changed to modelValue, but the watcher on value() was not renamed, which recalculates the nodes and triggers internalValue to be updated. See the PR change.

Many thanks
